### PR TITLE
Using go.k8s.io for pointing to OWNERS docs

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,4 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
 - childsb

--- a/release-tools/OWNERS
+++ b/release-tools/OWNERS
@@ -1,11 +1,11 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+# See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-- saad-ali
 - msau42
 - pohly
+- saad-ali
 
 reviewers:
-- saad-ali
 - msau42
 - pohly
+- saad-ali


### PR DESCRIPTION
As the title says. I've sorted the `release-tools/OWNERS` as well.

```release-note
NONE
```

/assign @saad-ali