### PR TITLE
Remove Brad Childs from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,6 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- childsb
 - j-griffith
 - msau42
 - saad-ali


### PR DESCRIPTION
This PR remove Brad Childs' github ID from the OWNERS files where it appears.

Associated with kubernetes/community#4418