### PR TITLE
iscsi: capture and log iscsi disconnect error

### DIFF
--- a/pkg/iscsi/iscsi.go
+++ b/pkg/iscsi/iscsi.go
@@ -60,7 +60,7 @@ func getISCSIInfo(req *csi.NodePublishVolumeRequest) (*iscsiDisk, error) {
 	}
 
 	for _, portal := range portals {
-		bkportal = append(bkportal, portalMounter(string(portal)))
+		bkportal = append(bkportal, portalMounter(portal))
 	}
 
 	iface := req.GetVolumeContext()["iscsiInterface"]

--- a/pkg/iscsi/iscsi_util.go
+++ b/pkg/iscsi/iscsi_util.go
@@ -109,9 +109,10 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, targetPath string) error
 		return err
 	}
 
-	iscsiLib.Disconnect(connector.TargetIqn, connector.TargetPortals)
-
-	if err := os.RemoveAll(targetPath); err != nil {
+	if disConnectErr := iscsiLib.Disconnect(connector.TargetIqn, connector.TargetPortals); disConnectErr != nil {
+		klog.Warningf("Warning: Disconnect failed for IQN: %v", connector.TargetIqn)
+	}
+	if err := os.Remove(targetPath); err != nil {
 		klog.Errorf("iscsi: failed to remove mount path Error: %v", err)
 		return err
 	}


### PR DESCRIPTION

    iscsi: capture/log iscsi disconnect error and call safe removal
    
    At present while iscsi target disconnect is attempted, if there is
    an error its ignored. This patch fetches the error if any and also
    log it for further actions. Also to avoid accidental deletion of
    user data we go with safe path of os.remove()


Signed-off-by: Humble Chirammal <hchiramm@redhat.com>

