### PR TITLE
address error return and unwanted type conversion

### DIFF
--- a/pkg/iscsi/controllerserver.go
+++ b/pkg/iscsi/controllerserver.go
@@ -57,7 +57,7 @@ func (cs *ControllerServer) GetCapacity(ctx context.Context, req *csi.GetCapacit
 }
 
 // ControllerGetCapabilities implements the default GRPC callout.
-// Default supports all capabilities
+// Default supports all capabilities.
 func (cs *ControllerServer) ControllerGetCapabilities(ctx context.Context, req *csi.ControllerGetCapabilitiesRequest) (*csi.ControllerGetCapabilitiesResponse, error) {
 	klog.V(5).Infof("Using default ControllerGetCapabilities")
 

--- a/pkg/iscsi/iscsi.go
+++ b/pkg/iscsi/iscsi.go
@@ -60,7 +60,7 @@ func getISCSIInfo(req *csi.NodePublishVolumeRequest) (*iscsiDisk, error) {
 	}
 
 	for _, portal := range portals {
-		bkportal = append(bkportal, portalMounter(string(portal)))
+		bkportal = append(bkportal, portalMounter(portal))
 	}
 
 	iface := req.GetVolumeContext()["iscsiInterface"]
@@ -151,7 +151,7 @@ func getISCSIDiskUnmounter(req *csi.NodeUnpublishVolumeRequest) *iscsiDiskUnmoun
 
 func portalMounter(portal string) string {
 	if !strings.Contains(portal, ":") {
-		portal = portal + ":3260"
+		portal += ":3260"
 	}
 	return portal
 }

--- a/pkg/iscsi/iscsi_util.go
+++ b/pkg/iscsi/iscsi_util.go
@@ -41,7 +41,7 @@ func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
 	mntPath := b.targetPath
 	notMnt, err := b.mounter.IsLikelyNotMountPoint(mntPath)
 	if err != nil && !os.IsNotExist(err) {
-		return "", fmt.Errorf("Heuristic determination of mount point failed:%v", err)
+		return "", fmt.Errorf("heuristic determination of mount point failed:%v", err)
 	}
 	if !notMnt {
 		klog.Infof("iscsi: %s already mounted", mntPath)
@@ -86,7 +86,7 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, targetPath string) error
 		return err
 	}
 	if pathExists, pathErr := mount.PathExists(targetPath); pathErr != nil {
-		return fmt.Errorf("Error checking if path exists: %v", pathErr)
+		return fmt.Errorf("error checking if path exists: %v", pathErr)
 	} else if !pathExists {
 		klog.Warningf("Warning: Unmount skipped because path does not exist: %v", targetPath)
 		return nil
@@ -128,6 +128,7 @@ func (util *ISCSIUtil) DetachDisk(c iscsiDiskUnmounter, targetPath string) error
 	}
 
 	klog.Info("successfully detached ISCSI device")
+
 	return nil
 
 }

--- a/pkg/iscsi/server.go
+++ b/pkg/iscsi/server.go
@@ -27,15 +27,15 @@ import (
 	"k8s.io/klog/v2"
 )
 
-// Defines Non blocking GRPC server interfaces
+// Defines Non blocking GRPC server interfaces.
 type NonBlockingGRPCServer interface {
 	// Start services at the endpoint
 	Start(endpoint string, ids csi.IdentityServer, cs csi.ControllerServer, ns csi.NodeServer)
-	// Waits for the service to stop
+	// Wait waits for the service to stop
 	Wait()
-	// Stops the service gracefully
+	// Stop stops the service gracefully
 	Stop()
-	// Stops the service forcefully
+	// ForceStop Stops the service forcefully
 	ForceStop()
 }
 
@@ -104,9 +104,10 @@ func (s *nonBlockingGRPCServer) serve(endpoint string, ids csi.IdentityServer, c
 	if ns != nil {
 		csi.RegisterNodeServer(server, ns)
 	}
-
 	klog.Infof("Listening for connections on address: %#v", listener.Addr())
-
-	server.Serve(listener)
+	err = server.Serve(listener)
+	if err != nil {
+		klog.Fatalf("Failed to serve requests: %v", err)
+	}
 
 }


### PR DESCRIPTION
this commit address unhandled error returns and also correct
duplicated conversion of a type along with other linter fixes

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup

-->
```release-note-none

```
