### PR TITLE
fix: driver pod crash when portals are not provided

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.1.0
 
 RUN apt update && apt-mark unhold libcap2
-RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs btrfs-progs
+RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs btrfs-progs open-iscsi
 # install updated packages to fix CVE issues
 RUN clean-install libgmp10 bsdutils
 

--- a/pkg/iscsi/iscsi.go
+++ b/pkg/iscsi/iscsi.go
@@ -103,7 +103,7 @@ func getISCSIInfo(req *csi.NodePublishVolumeRequest) (*iscsiDisk, error) {
 }
 
 func buildISCSIConnector(iscsiInfo *iscsiDisk) *iscsiLib.Connector {
-	if iscsiInfo == nil || iscsiInfo.VolName == "" || iscsiInfo.Iqn == "" || len(iscsiInfo.Portals) == 0 {
+	if iscsiInfo == nil || iscsiInfo.VolName == "" || iscsiInfo.Iqn == "" {
 		return nil
 	}
 	c := iscsiLib.Connector{

--- a/pkg/iscsi/iscsi_util.go
+++ b/pkg/iscsi/iscsi_util.go
@@ -31,6 +31,10 @@ import (
 type ISCSIUtil struct{}
 
 func (util *ISCSIUtil) AttachDisk(b iscsiDiskMounter) (string, error) {
+	if b.connector == nil {
+		return "", fmt.Errorf("connector is nil")
+	}
+
 	devicePath, err := (*b.connector).Connect()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
 /kind bug

**What this PR does / why we need it**:
fix: driver pod crash when portals are not provided

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
fix: driver pod crash when portals are not provided
```
