### PR TITLE
chore: change the registry path to registry.k8s.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.2.0
+FROM registry.k8s.io/build-image/debian-base:bullseye-v1.2.0
 
 RUN apt update && apt upgrade -y && apt-mark unhold libcap2
 RUN clean-install util-linux e2fsprogs mount ca-certificates udev xfsprogs btrfs-progs open-iscsi

--- a/deploy/csi-iscsi-node.yaml
+++ b/deploy/csi-iscsi-node.yaml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: liveness-probe
-          image: k8s.gcr.io/sig-storage/livenessprobe:v2.1.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.1.0
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -42,7 +42,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
-          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.1.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.1.0
           args:
             - --v=2
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
This commit change the registry path of the plugin image from k8s.gcr.io
to registry.k8s.io

Refer# https://github.com/kubernetes/k8s.io/wiki/New-Registry-url-for-Kubernetes-(registry.k8s.io)

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>



> /kind cleanup
```release-note
NONE
```
