### PR TITLE
GitHub: enable dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10
+- package-ecosystem: "github-actions"
+  directory: "/"
+  schedule:
+      interval: "daily"
+  labels:
+    - "area/dependency"
+    - "release-note-none"
+    - "ok-to-test"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
Automatically updating dependencies saves on manual labor. The PRs created by
the bot are also more informative.

k8s.io packages are excluded. At least the staging repos don't have API
stability guarantees and better should get updated manually.

Signed-off-by: Humble Chirammal <hchiramm@redhat.com>


> /kind cleanup


**Special notes for your reviewer**:

This is pretty much copy of csi-test PR here https://github.com/kubernetes-csi/csi-test/pull/365
```release-note
none
```
