### PR TITLE
chore: update golang lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,10 +10,10 @@ jobs:
             - name: Set up Go 1.x
               uses: actions/setup-go@v5
               with:
-                go-version: ^1.19
+                go-version: ^1.22
             - uses: actions/checkout@master
             - name: Run linter
               uses: golangci/golangci-lint-action@v6
               with:
-                  version: v1.54
-                  args: -E=gofmt,unused,ineffassign,misspell,exportloopref,asciicheck,bodyclose,dogsled,durationcheck,errname,forbidigo -D=staticcheck --timeout=30m0s
+                  version: v1.61
+                  args: -E=gofmt,unused,ineffassign,misspell,copyloopvar,asciicheck,bodyclose,dogsled,durationcheck,errname,forbidigo -D=staticcheck --timeout=30m0s

--- a/pkg/iscsilib/iscsi.go
+++ b/pkg/iscsilib/iscsi.go
@@ -517,7 +517,7 @@ func GetISCSIDevices(devicePaths []string, strict bool) (devices []Device, err e
 func lsblk(devicePaths []string, strict bool) (deviceInfo, error) {
 	flags := []string{"-rn", "-o", "NAME,KNAME,PKNAME,HCTL,TYPE,TRAN,SIZE"}
 	command := execCommand("lsblk", append(flags, devicePaths...)...)
-	klog.V(2).Infof(command.String())
+	klog.V(2).Info(command.String())
 	out, err := command.Output()
 	if err != nil {
 		if ee, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
**What type of PR is this?**

/kind failing-test

**What this PR does / why we need it**:

* golang version is 1.19 and go.mod is 1.22
* 1.51 golang-lint was compiled with too old a version of go
* exportloopref no long relevant using copyloopref instead
* Fixed new lint issue

**Which issue(s) this PR fixes**:


**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
NONE```
