### PR TITLE
chore: fix deprecated import

### DIFF
--- a/pkg/iscsilib/iscsi.go
+++ b/pkg/iscsilib/iscsi.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -666,7 +665,7 @@ func (c *Connector) Persist(filePath string) error {
 
 // GetConnectorFromFile attempts to create a Connector using the specified json file (ie /var/lib/pfile/myConnector.json)
 func GetConnectorFromFile(filePath string) (*Connector, error) {
-	f, err := ioutil.ReadFile(filePath)
+	f, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This usage has been deprecated since 1.16.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:

```release-note
none
```
