### PR TITLE
add discovery config to make iscsiadm discovery target

### DIFF
--- a/examples/pv.yaml
+++ b/examples/pv.yaml
@@ -20,5 +20,6 @@ spec:
       iqn: "iqn.2015-06.com.example.test:target1"
       lun: "0"
       iscsiInterface: "default"
+      discovery: "true"
       discoveryCHAPAuth: "true"
       sessionCHAPAuth: "false"

--- a/pkg/iscsi/iscsi.go
+++ b/pkg/iscsi/iscsi.go
@@ -77,6 +77,8 @@ func getISCSIInfo(req *csi.NodePublishVolumeRequest) (*iscsiDisk, error) {
 		chapSession = true
 	}
 
+	doDiscovery := req.GetVolumeContext()["discovery"] == "true"
+
 	var lunVal int32
 	if lun != "" {
 		l, err := strconv.Atoi(lun)
@@ -85,12 +87,14 @@ func getISCSIInfo(req *csi.NodePublishVolumeRequest) (*iscsiDisk, error) {
 		}
 		lunVal = int32(l)
 	}
+
 	iscsiDisk := &iscsiDisk{
 		VolName:         volName,
 		Portals:         bkportal,
 		Iqn:             iqn,
 		lun:             lunVal,
 		Iface:           iface,
+		discovery:       doDiscovery,
 		chapDiscovery:   chapDiscovery,
 		chapSession:     chapSession,
 		secret:          secret,
@@ -111,6 +115,7 @@ func buildISCSIConnector(iscsiInfo *iscsiDisk) *iscsiLib.Connector {
 		TargetIqn:        iscsiInfo.Iqn,
 		TargetPortals:    iscsiInfo.Portals,
 		Lun:              iscsiInfo.lun,
+		DoDiscovery:      iscsiInfo.discovery,
 		DoCHAPDiscovery:  iscsiInfo.chapDiscovery,
 		DiscoverySecrets: iscsiInfo.discoverySecret,
 		SessionSecrets:   iscsiInfo.sessionSecret,
@@ -230,6 +235,7 @@ type iscsiDisk struct {
 	Iqn             string
 	lun             int32
 	Iface           string
+	discovery       bool
 	chapDiscovery   bool
 	chapSession     bool
 	secret          map[string]string


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
3. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change

/kind bug

> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

add discovery config to make iscsiadm discovery target, otherwise the login will failed with `no records found`.

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->
```release-note
add new config

discovery: "true"
```
