### PR TITLE
chore: bump Go version to 1.25.11 in trivy workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
         with:
-          go-version: 1.25.10
+          go-version: 1.25.11
         id: go
 
       - name: Checkout code


### PR DESCRIPTION
## What this PR does

Bumps the Go version from 1.25.10 to 1.25.11 in the trivy security scan workflow to fix the following CVEs:

- **CVE-2026-27145**: x509.Certificate VerifyHostname vulnerability
- **CVE-2026-42504**: Malicious MIME header decoding issue
- **CVE-2026-42507**: net/textproto error handling vulnerability

All three are fixed in Go 1.25.11.

/kind cleanup


```release-note
NONE
```