### PR TITLE
chore: update CSI sidecar images to latest versions

### DIFF
--- a/deploy/csi-iscsi-node.yaml
+++ b/deploy/csi-iscsi-node.yaml
@@ -21,7 +21,7 @@ spec:
         kubernetes.io/os: linux
       containers:
         - name: liveness-probe
-          image: registry.k8s.io/sig-storage/livenessprobe:v2.10.0
+          image: registry.k8s.io/sig-storage/livenessprobe:v2.19.0
           args:
             - --csi-address=/csi/csi.sock
             - --probe-timeout=3s
@@ -42,7 +42,7 @@ spec:
           # created by privileged CSI driver container.
           securityContext:
             privileged: true
-          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0
+          image: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.17.0
           args:
             - --v=2
             - --csi-address=/csi/csi.sock


### PR DESCRIPTION
## What this PR does

Update CSI sidecar images to their latest releases:

| Sidecar | Before | After |
|---------|--------|-------|
| livenessprobe | v2.10.0 | v2.19.0 |
| csi-node-driver-registrar | v2.8.0 | v2.17.0 |

## Files changed

- `deploy/csi-iscsi-node.yaml`

## Release Notes

```release-note
Update CSI sidecar images to latest versions (livenessprobe v2.19.0, csi-node-driver-registrar v2.17.0)
```