### PR TITLE
bump github/codeql-action init+analyze from 4.36.3 to 4.37.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -48,7 +48,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/init@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -63,4 +63,4 @@ jobs:
         make all
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
+      uses: github/codeql-action/analyze@99df26d4f13ea111d4ec1a7dddef6063f76b97e9 # v4


### PR DESCRIPTION
Bumps github/codeql-action init and analyze from 4.36.3 (54f647b) to 4.37.0 (99df26d) in a single commit.

Dependabot opened a PR (#438) bumping only one of the two steps. Merging that on its own leaves init and analyze at mismatched versions, and CodeQL fails at the analyze step with:

```
Error: Loaded a configuration file for version 4.37.0, but running version 4.36.3
```

The init step writes a config file tagged with its own version and the analyze step refuses to run when the two do not match. Both must be bumped together.

Supersedes #438.